### PR TITLE
Add option to disable Short cuts/Hot keys

### DIFF
--- a/packages/selenium-ide/src/neo/components/ActionButtons/DisableBreakpoints/index.jsx
+++ b/packages/selenium-ide/src/neo/components/ActionButtons/DisableBreakpoints/index.jsx
@@ -19,15 +19,17 @@ import React from 'react'
 import ActionButton from '../ActionButton'
 import classNames from 'classnames'
 import { parse } from 'modifier-keys'
+import UiState from '../../../stores/view/UiState'
 
 export default class DisableBreakpointsButton extends React.Component {
   render() {
     return (
       <ActionButton
-        data-tip={`<p>Disable breakpoints <span style="color: #929292;padding-left: 5px;">${parse(
-          'y',
-          { primaryKey: true }
-        )}</span></p>`}
+        data-tip={`<p>Disable breakpoints <span style="color: #929292;padding-left: 5px;">${
+          !UiState.keyboardShortcutsEnabled
+            ? ''
+            : parse('y', { primaryKey: true })
+        }</span></p>`}
         {...this.props}
         className={classNames('si-disable-breakpoints', this.props.className)}
         aria-label="Disable breakpoints"

--- a/packages/selenium-ide/src/neo/components/ActionButtons/New/index.jsx
+++ b/packages/selenium-ide/src/neo/components/ActionButtons/New/index.jsx
@@ -19,16 +19,18 @@ import React from 'react'
 import ActionButton from '../ActionButton'
 import classNames from 'classnames'
 import { parse } from 'modifier-keys'
+import UiState from '../../../stores/view/UiState'
 
 export default class NewButton extends React.Component {
   render() {
     const props = { ...this.props }
     return (
       <ActionButton
-        data-tip={`<p>Create new project <span style="color: #929292;padding-left: 5px;">${parse(
-          'n',
-          { primaryKey: true, shiftKey: true }
-        )}</span></p>`}
+        data-tip={`<p>Create new project <span style="color: #929292;padding-left: 5px;">${
+          !UiState.keyboardShortcutsEnabled
+            ? ''
+            : parse('n', { primaryKey: true, shiftKey: true })
+        }</span></p>`}
         {...props}
         className={classNames('si-new-project', this.props.className)}
         aria-label="Create new project"

--- a/packages/selenium-ide/src/neo/components/ActionButtons/Open/index.jsx
+++ b/packages/selenium-ide/src/neo/components/ActionButtons/Open/index.jsx
@@ -19,6 +19,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import uuidv4 from 'uuid/v4'
 import { parse } from 'modifier-keys'
+import UiState from '../../../stores/view/UiState'
 import './style.css'
 
 export default class OpenButton extends React.Component {
@@ -85,10 +86,11 @@ export class OpenInput extends React.Component {
           ref={label => {
             this.label = label
           }}
-          data-tip={`<p>Open project <span style="color: #929292;padding-left: 5px;">${parse(
-            'o',
-            { primaryKey: true }
-          )}</span></p>`}
+          data-tip={`<p>Open project <span style="color: #929292;padding-left: 5px;">${
+            !UiState.keyboardShortcutsEnabled
+              ? ''
+              : parse('o', { primaryKey: true })
+          }</span></p>`}
           // We need special events because Focus and Blur are lost before the tooltip is shown
           data-event="focusexternal mouseenter"
           data-event-off="blurexternal mouseleave"

--- a/packages/selenium-ide/src/neo/components/ActionButtons/Pause/index.jsx
+++ b/packages/selenium-ide/src/neo/components/ActionButtons/Pause/index.jsx
@@ -19,15 +19,17 @@ import React from 'react'
 import ActionButton from '../ActionButton'
 import classNames from 'classnames'
 import { parse } from 'modifier-keys'
+import UiState from '../../../stores/view/UiState'
 
 export default class PauseCurrentButton extends React.Component {
   render() {
     return (
       <ActionButton
-        data-tip={`<p>Pause test execution <span style="color: #929292;padding-left: 5px;">${parse(
-          'p',
-          { primaryKey: true }
-        )}</span></p>`}
+        data-tip={`<p>Pause test execution <span style="color: #929292;padding-left: 5px;">${
+          !UiState.keyboardShortcutsEnabled
+            ? ''
+            : parse('p', { primaryKey: true })
+        }</span></p>`}
         {...this.props}
         className={classNames('si-pause', this.props.className)}
       /> // eslint-disable-line react/prop-types

--- a/packages/selenium-ide/src/neo/components/ActionButtons/PlayAll/index.jsx
+++ b/packages/selenium-ide/src/neo/components/ActionButtons/PlayAll/index.jsx
@@ -19,15 +19,17 @@ import React from 'react'
 import ActionButton from '../ActionButton'
 import classNames from 'classnames'
 import { parse } from 'modifier-keys'
+import UiState from '../../../stores/view/UiState'
 
 export default class PlayAllButton extends React.Component {
   render() {
     return (
       <ActionButton
-        data-tip={`<p>Run all tests in suite <span style="color: #929292;padding-left: 5px;">${parse(
-          'r',
-          { primaryKey: true, shiftKey: true }
-        )}</span></p>`}
+        data-tip={`<p>Run all tests in suite <span style="color: #929292;padding-left: 5px;">${
+          !UiState.keyboardShortcutsEnabled
+            ? ''
+            : parse('r', { primaryKey: true, shiftKey: true })
+        }</span></p>`}
         aria-label="Run all tests in suite"
         {...this.props}
         className={classNames('si-play-all', this.props.className)}

--- a/packages/selenium-ide/src/neo/components/ActionButtons/PlayCurrent/index.jsx
+++ b/packages/selenium-ide/src/neo/components/ActionButtons/PlayCurrent/index.jsx
@@ -19,15 +19,17 @@ import React from 'react'
 import ActionButton from '../ActionButton'
 import classNames from 'classnames'
 import { parse } from 'modifier-keys'
+import UiState from '../../../stores/view/UiState'
 
 export default class PlayCurrentButton extends React.Component {
   render() {
     return (
       <ActionButton
-        data-tip={`<p>Run current test <span style="color: #929292;padding-left: 5px;">${parse(
-          'r',
-          { primaryKey: true }
-        )}</span></p>`}
+        data-tip={`<p>Run current test <span style="color: #929292;padding-left: 5px;">${
+          !UiState.keyboardShortcutsEnabled
+            ? ''
+            : parse('r', { primaryKey: true })
+        }</span></p>`}
         {...this.props}
         className={classNames('si-play', this.props.className)}
       /> // eslint-disable-line react/prop-types

--- a/packages/selenium-ide/src/neo/components/ActionButtons/Record/index.jsx
+++ b/packages/selenium-ide/src/neo/components/ActionButtons/Record/index.jsx
@@ -18,6 +18,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import ActionButton from '../ActionButton'
+import UiState from '../../../stores/view/UiState'
 import { parse } from 'modifier-keys'
 import './style.css'
 
@@ -33,14 +34,16 @@ export default class Record extends React.Component {
         className="record"
         data-tip={
           this.props.isRecording
-            ? `<p>Stop recording <span style="color: #929292;padding-left: 5px;">${parse(
-                'u',
-                { primaryKey: true }
-              )}</span></p>`
-            : `<p>Start recording <span style="color: #929292;padding-left: 5px;">${parse(
-                'u',
-                { primaryKey: true }
-              )}</span></p>`
+            ? `<p>Stop recording <span style="color: #929292;padding-left: 5px;">${
+                !UiState.keyboardShortcutsEnabled
+                  ? ''
+                  : parse('u', { primaryKey: true })
+              }</span></p>`
+            : `<p>Start recording <span style="color: #929292;padding-left: 5px;">${
+                !UiState.keyboardShortcutsEnabled
+                  ? ''
+                  : parse('u', { primaryKey: true })
+              }</span></p>`
         }
         data-event="focus mouseenter"
         data-event-off="blur mouseleave"

--- a/packages/selenium-ide/src/neo/components/ActionButtons/Save/index.jsx
+++ b/packages/selenium-ide/src/neo/components/ActionButtons/Save/index.jsx
@@ -19,6 +19,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import ActionButton from '../ActionButton'
 import classNames from 'classnames'
+import UiState from '../../../stores/view/UiState'
 import { parse } from 'modifier-keys'
 import './style.css'
 
@@ -28,10 +29,11 @@ export default class SaveButton extends React.Component {
     delete props.unsaved
     return (
       <ActionButton
-        data-tip={`<p>Save project <span style="color: #929292;padding-left: 5px;">${parse(
-          's',
-          { primaryKey: true }
-        )}</span></p>`}
+        data-tip={`<p>Save project <span style="color: #929292;padding-left: 5px;">${
+          !UiState.keyboardShortcutsEnabled
+            ? ''
+            : parse('s', { primaryKey: true })
+        }</span></p>`}
         {...props}
         className={classNames(
           'si-save',

--- a/packages/selenium-ide/src/neo/components/ActionButtons/StepInto/index.jsx
+++ b/packages/selenium-ide/src/neo/components/ActionButtons/StepInto/index.jsx
@@ -18,16 +18,18 @@
 import React from 'react'
 import ActionButton from '../ActionButton'
 import classNames from 'classnames'
+import UiState from '../../../stores/view/UiState'
 import { parse } from 'modifier-keys'
 
 export default class StepIntoButton extends React.Component {
   render() {
     return (
       <ActionButton
-        data-tip={`<p>Step over current command <span style="color: #929292;padding-left: 5px;">${parse(
-          "'",
-          { primaryKey: true }
-        )}</span></p>`}
+        data-tip={`<p>Step over current command <span style="color: #929292;padding-left: 5px;">${
+          !UiState.keyboardShortcutsEnabled
+            ? ''
+            : parse("'", { primaryKey: true })
+        }</span></p>`}
         {...this.props}
         className={classNames('si-step-down', this.props.className)}
       /> // eslint-disable-line react/prop-types

--- a/packages/selenium-ide/src/neo/components/ActionButtons/Stop/index.jsx
+++ b/packages/selenium-ide/src/neo/components/ActionButtons/Stop/index.jsx
@@ -18,16 +18,18 @@
 import React from 'react'
 import ActionButton from '../ActionButton'
 import classNames from 'classnames'
+import UiState from '../../../stores/view/UiState'
 import { parse } from 'modifier-keys'
 
 export default class StopButton extends React.Component {
   render() {
     return (
       <ActionButton
-        data-tip={`<p>Stop test execution <span style="color: #929292;padding-left: 5px;">${parse(
-          '.',
-          { primaryKey: true }
-        )}</span></p>`}
+        data-tip={`<p>Stop test execution <span style="color: #929292;padding-left: 5px;">${
+          !UiState.keyboardShortcutsEnabled
+            ? ''
+            : parse('.', { primaryKey: true })
+        }</span></p>`}
         {...this.props}
         className={classNames('si-stop', this.props.className)}
       /> // eslint-disable-line react/prop-types

--- a/packages/selenium-ide/src/neo/components/ProjectHeader/index.jsx
+++ b/packages/selenium-ide/src/neo/components/ProjectHeader/index.jsx
@@ -27,6 +27,7 @@ import SaveButton from '../ActionButtons/Save'
 import MoreButton from '../ActionButtons/More'
 import ListMenu, { ListMenuItem } from '../ListMenu'
 import './style.css'
+import UiState from '../../stores/view/UiState'
 
 @observer
 export default class ProjectHeader extends React.Component {
@@ -97,6 +98,11 @@ export default class ProjectHeader extends React.Component {
             </ListMenuItem>
             <ListMenuItem href="https://www.seleniumhq.org/selenium-ide/docs/en/introduction/getting-started/">
               {'Help'}
+            </ListMenuItem>
+            <ListMenuItem onClick={() => UiState.toggleKeyboardShortcuts()}>
+              {`${
+                UiState.keyboardShortcutsEnabled ? 'Disable' : 'Enable'
+              } the Keyboard Shortcuts`}
             </ListMenuItem>
           </ListMenu>
         </span>

--- a/packages/selenium-ide/src/neo/components/TabBar/index.jsx
+++ b/packages/selenium-ide/src/neo/components/TabBar/index.jsx
@@ -75,10 +75,7 @@ export default class TabBar extends React.Component {
   }
   render() {
     return (
-      <div
-        className="tabbar"
-        onKeyDown={this.handleKeyDown.bind(this)}
-      >
+      <div className="tabbar" onKeyDown={this.handleKeyDown.bind(this)}>
         <ul role="tablist">
           {this.props.tabs.map((tab, index) => (
             <li

--- a/packages/selenium-ide/src/neo/components/ToolBar/index.jsx
+++ b/packages/selenium-ide/src/neo/components/ToolBar/index.jsx
@@ -17,7 +17,6 @@
 
 import React from 'react'
 import { observer } from 'mobx-react'
-import { parse } from 'modifier-keys'
 import PlayAll from '../../components/ActionButtons/PlayAll'
 import PlayCurrent from '../../components/ActionButtons/PlayCurrent'
 import Pause from '../../components/ActionButtons/Pause'
@@ -29,6 +28,7 @@ import PauseExceptions from '../../components/ActionButtons/PauseExceptions'
 import Record from '../../components/ActionButtons/Record'
 import GaugeMenu from '../GaugeMenu'
 import UiState from '../../stores/view/UiState'
+import { parse } from 'modifier-keys'
 import PlaybackState from '../../stores/view/PlaybackState'
 import ModalState from '../../stores/view/ModalState'
 import './style.css'
@@ -66,14 +66,16 @@ export default class ToolBar extends React.Component {
           onClick={this.playAll}
           data-tip={
             PlaybackState.canPlaySuite
-              ? `<p>Run all tests in suite <span style="color: #929292;padding-left: 5px;">${parse(
-                  'r',
-                  { primaryKey: true, shiftKey: true }
-                )}</span></p>`
-              : `<p>Run all tests <span style="color: #929292;padding-left: 5px;">${parse(
-                  'r',
-                  { primaryKey: true, shiftKey: true }
-                )}</span></p>`
+              ? `<p>Run all tests in suite <span style="color: #929292;padding-left: 5px;">${
+                  !UiState.keyboardShortcutsEnabled
+                    ? ''
+                    : parse('r', { primaryKey: true, shiftKey: true })
+                }</span></p>`
+              : `<p>Run all tests <span style="color: #929292;padding-left: 5px;">${
+                  !UiState.keyboardShortcutsEnabled
+                    ? ''
+                    : parse('r', { primaryKey: true, shiftKey: true })
+                }</span></p>`
           }
           data-event="focus mouseenter"
           data-event-off="blur mouseleave"
@@ -102,14 +104,16 @@ export default class ToolBar extends React.Component {
             isActive={PlaybackState.paused}
             data-tip={
               !PlaybackState.paused
-                ? `<p>Pause test execution <span style="color: #929292;padding-left: 5px;">${parse(
-                    'p',
-                    { primaryKey: true }
-                  )}</span></p>`
-                : `<p>Resume test execution <span style="color: #929292;padding-left: 5px;">${parse(
-                    'p',
-                    { primaryKey: true }
-                  )}</span></p>`
+                ? `<p>Pause test execution <span style="color: #929292;padding-left: 5px;">${
+                    !UiState.keyboardShortcutsEnabled
+                      ? ''
+                      : parse('p', { primaryKey: true })
+                  }</span></p>`
+                : `<p>Resume test execution <span style="color: #929292;padding-left: 5px;">${
+                    !UiState.keyboardShortcutsEnabled
+                      ? ''
+                      : parse('p', { primaryKey: true })
+                  }</span></p>`
             }
             data-event="focus mouseenter"
             data-event-off="blur mouseleave"

--- a/packages/selenium-ide/src/neo/components/VerticalTabBar/index.jsx
+++ b/packages/selenium-ide/src/neo/components/VerticalTabBar/index.jsx
@@ -17,6 +17,7 @@
 
 import React from 'react'
 import PropTypes from 'prop-types'
+import UiState from '../../stores/view/UiState'
 import { parse } from 'modifier-keys'
 import ListMenu, { ListMenuItem } from '../ListMenu'
 import { MenuDirections } from '../Menu'
@@ -71,7 +72,11 @@ export default class VerticalTabBar extends React.Component {
             {this.props.tabs.map((tab, i) => (
               <ListMenuItem
                 key={tab}
-                label={parse(`${i + 1}`, { primaryKey: true })}
+                label={
+                  !UiState.keyboardShortcutsEnabled
+                    ? `${i + 1}`
+                    : parse(`${i + 1}`, { primaryKey: true })
+                }
                 onClick={this.handleClick.bind(this, tab)}
               >
                 {tab}

--- a/packages/selenium-ide/src/neo/containers/Panel/index.jsx
+++ b/packages/selenium-ide/src/neo/containers/Panel/index.jsx
@@ -156,6 +156,12 @@ export default class Panel extends React.Component {
     }
   }
   handleKeyDown(e) {
+    // We want to enable disabling these Key Combinations for Accessibility
+    if (!UiState.keyboardShortcutsEnabled) {
+      e.preventDefault()
+      return
+    }
+
     const keyComb = this.parseKeyDown(e)
     // when editing these, remember to edit the button's tooltip as well
     if (keyComb.primaryAndShift && keyComb.key === 'N') {

--- a/packages/selenium-ide/src/neo/stores/view/UiState.js
+++ b/packages/selenium-ide/src/neo/stores/view/UiState.js
@@ -76,6 +76,8 @@ class UiState {
   specifiedRemoteUrl = null
   @observable
   gridConfigEnabled = null
+  @observable
+  _keyboardShortcutsEnabled = true
 
   dialogButtonDirection = 'normal'
 
@@ -215,6 +217,11 @@ class UiState {
       this.selectedTest.stack < PlaybackState.callstack.length
       ? PlaybackState.callstack[this.selectedTest.stack].callee
       : this.selectedTest.test
+  }
+
+  @computed
+  get keyboardShortcutsEnabled() {
+    return this._keyboardShortcutsEnabled
   }
 
   @action.bound
@@ -587,6 +594,11 @@ class UiState {
   @action.bound
   startConnection() {
     this.isControlled = true
+  }
+
+  @action.bound
+  toggleKeyboardShortcuts() {
+    this._keyboardShortcutsEnabled = !this._keyboardShortcutsEnabled
   }
 }
 


### PR DESCRIPTION
### Description
WCAG2.1  requires us to provide a way to change or disable the hot keys for keyboard user.

This PR adds an option to disable and re enable the Shortcuts. The shortcuts start in an active state, the user can disable or enable them at their leisure.

### Motivation and Context
Keyboard users will have issues with the hotkeys if they intercept or otherwise prevent certain commands from working. For example a person with hard of sight might've configured one short cut in an Accessibility Tool that gets intercepted and consumed by Selenium IDE which would lead to that Hot Key not working as expected for the user.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium-ide/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
